### PR TITLE
Force calibration with OSC message

### DIFF
--- a/kaz.ino
+++ b/kaz.ino
@@ -96,6 +96,7 @@ void handleTwizData(OSCMessage &message) {
 // Handle for force calibration
 void handleForceCalibrate(OSCMessage &message) {
   calibrated = false;
+  stepperOffset = 0;
 }
 
 // Handler for the override data. Expects the value to be a float between 0.0 and 1.0.


### PR DESCRIPTION
I've added another OSC message to force the calibration, thus every time the game restarts it can reset the motor to it's zero.
I've noticed some drifting over time and needed constantly reset the Arduino.
